### PR TITLE
Ensure mirror list can be read by all users

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -16,6 +16,7 @@ class aptmirror(
 
   file { '/etc/apt/mirror.list':
     content => template('aptmirror/etc/apt/mirror.list'),
+    mode    => '444'
   }
 
   Aptmirror::Source<| |> -> File['/etc/apt/mirror.list']


### PR DESCRIPTION
Puppet seems to be setting this back to 400 which makes it impossible to run `apt-mirror` as the `apt-mirror` user.

/cc https://github.com/github/puppet/pull/2281
