### PR TITLE
Add url param to aptmirror::source

### DIFF
--- a/manifests/source.pp
+++ b/manifests/source.pp
@@ -1,6 +1,7 @@
 define aptmirror::source(
     $distributions,
     $components,
+    $url    = $name,
     $clean  = false,
     $amd64  = true,
     $i386   = false,
@@ -12,4 +13,5 @@ define aptmirror::source(
   validate_bool($amd64)
   validate_bool($i386)
   validate_bool($source)
+  validate_string($url)
 }

--- a/spec/classes/aptmirror_spec.rb
+++ b/spec/classes/aptmirror_spec.rb
@@ -38,7 +38,8 @@ describe 'aptmirror' do
 
   context 'with an aptmirror::source' do
     let(:pre_condition) { <<-EOF
-      aptmirror::source { 'http://us.archive.ubuntu.com':
+      aptmirror::source { 'http://us.archive.ubuntu.com foo':
+        url           => 'http://us.archive.ubuntu.com',
         distributions => ['precise', 'precise-security'],
         components    => ['main', 'restricted'],
         clean         => true,

--- a/templates/etc/apt/mirror.list
+++ b/templates/etc/apt/mirror.list
@@ -15,22 +15,22 @@ set _tilde            <%= @_tilde %>
 
 <% @sources.select { |r| r[:source].to_s == 'true' }.each do |source| -%>
 <% source[:distributions].each do |dist| -%>
-deb-src <%= source.title %> <%= dist %> <%= source[:components].join(' ') %>
+deb-src <%= source[:url] %> <%= dist %> <%= source[:components].join(' ') %>
 <% end -%>
 <% end -%>
 
 <% @sources.select { |r| r[:amd64].to_s == 'true' }.each do |source| -%>
 <% source[:distributions].each do |dist| -%>
-deb-amd64 <%= source.title %> <%= dist %> <%= source[:components].join(' ') %>
+deb-amd64 <%= source[:url] %> <%= dist %> <%= source[:components].join(' ') %>
 <% end -%>
 <% end -%>
 
 <% @sources.select { |r| r[:i386].to_s == 'true' }.each do |source| -%>
 <% source[:distributions].each do |dist| -%>
-deb-i386 <%= source.title %> <%= dist %> <%= source[:components].join(' ') %>
+deb-i386 <%= source[:url] %> <%= dist %> <%= source[:components].join(' ') %>
 <% end -%>
 <% end -%>
 
 <% @sources.select { |r| r[:clean].to_s == 'true' }.each do |source| -%>
-clean <%= source.title %>
+clean <%= source[:url] %>
 <% end -%>


### PR DESCRIPTION
So that we can multiple `aptmirror::source` instances pulling packages from the one mirror but with different options.
